### PR TITLE
Implement removal of metadata from paths

### DIFF
--- a/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/PrismContainer.java
+++ b/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/PrismContainer.java
@@ -24,7 +24,7 @@ import java.util.*;
  * Prism container groups items into logical blocks. The reason for
  * grouping may be as simple as better understandability of data structure. But
  * the group usually means different meaning, source or structure of the data.
- * For example, the a container is frequently used to hold properties
+ * For example, the container is frequently used to hold properties
  * that are dynamic, not fixed by a static schema. Such grouping also naturally
  * translates to XML and helps to "quarantine" such properties to avoid Unique
  * Particle Attribute problems.

--- a/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/PrismContainerValue.java
+++ b/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/PrismContainerValue.java
@@ -6,14 +6,16 @@
  */
 package com.evolveum.midpoint.prism;
 
-import java.util.*;
+import static com.evolveum.midpoint.util.MiscUtil.stateCheck;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.xml.namespace.QName;
-
-import com.evolveum.midpoint.prism.schema.SchemaLookup;
-import com.evolveum.midpoint.util.annotation.Unused;
-import com.evolveum.midpoint.util.exception.CommonException;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -22,14 +24,15 @@ import org.jetbrains.annotations.Nullable;
 import com.evolveum.midpoint.prism.equivalence.EquivalenceStrategy;
 import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.prism.schema.SchemaLookup;
+import com.evolveum.midpoint.util.annotation.Unused;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.util.exception.SchemaException;
-
-import static com.evolveum.midpoint.util.MiscUtil.stateCheck;
 
 /**
  * @author semancik
  */
-public interface PrismContainerValue<C extends Containerable> extends PrismValue, ParentVisitable {
+public interface PrismContainerValue<C extends Containerable> extends PrismValue, ParentVisitable, Walkable {
 
     static <T extends Containerable> T asContainerable(PrismContainerValue<T> value) {
         return value != null ? value.asContainerable() : null;
@@ -339,6 +342,17 @@ public interface PrismContainerValue<C extends Containerable> extends PrismValue
 
     // TODO optimize a bit + test thoroughly
     void removePaths(List<? extends ItemPath> remove) throws SchemaException;
+
+    /**
+     * Remove metadata from specified paths
+     *
+     * Can also remove metadata from the object on which it's called, if the paths contains a "root" path (e.g.
+     * {@code ItemPath.fromString("/")}).
+     *
+     * @param pathsToRemoveMetadata the paths to items on which metadata should be removed.
+     * @throws SchemaException
+     */
+    void removeMetadataFromPaths(List<? extends ItemPath> pathsToRemoveMetadata) throws SchemaException;
 
     void removeItems(List<? extends ItemPath> itemsToRemove);
 

--- a/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/Walkable.java
+++ b/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/Walkable.java
@@ -1,0 +1,34 @@
+package com.evolveum.midpoint.prism;
+
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.util.exception.SchemaException;
+
+/**
+ * Allow to walk conditionally through an object hierarchy
+ */
+public interface Walkable {
+
+    /**
+     * Walk through hierarchy of containing items based on provided conditions.
+     *
+     * Caller can provide two types of conditions. One ({@code consumePredicate}) is used to decide if currently
+     * iterated item should be consumed (by provided {@code itemConsumer}). Second ({@code descendPredicate}) tells, if
+     * walk should descend into currently iterated item.
+     *
+     * Descending condition is a BiPredicate in order to allow caller decide not just based on item path, but also
+     * based on the fact if the item was also consumed (depending on implementation, the results of
+     * {@code consumePredicate} could be directly passed to the descending condition).
+     *
+     * @param descendPredicate the {@code BiPredicate} which tells whether to descend into current item. Boolean
+     * parameter tells whether the item was also consumed or not.
+     * @param consumePredicate the {@code Predicate} which tells whether to consume current item.
+     * @param itemConsumer the consumer to consume item with if it passes the {@code consumePredicate} test.
+     * @throws SchemaException when something wrong happen during the walk.
+     */
+    void walk(BiPredicate<? super ItemPath, Boolean> descendPredicate, Predicate<? super ItemPath> consumePredicate,
+            Consumer<? super Item<?, ?>> itemConsumer) throws SchemaException;
+}

--- a/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/deleg/PrismContainerValueDelegator.java
+++ b/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/deleg/PrismContainerValueDelegator.java
@@ -27,6 +27,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public interface PrismContainerValueDelegator<C extends Containerable> extends PrismContainerValue<C> {
@@ -322,6 +325,10 @@ public interface PrismContainerValueDelegator<C extends Containerable> extends P
         delegate().removePaths(remove);
     }
 
+    default void removeMetadataFromPaths(List<? extends ItemPath> pathsToRemoveMetadata) throws SchemaException {
+        delegate().removeMetadataFromPaths(pathsToRemoveMetadata);
+    }
+
     default <IV extends PrismValue, ID extends ItemDefinition<?>> boolean merge(Item<IV, ID> item) throws SchemaException {
         return delegate().merge(item);
     }
@@ -581,6 +588,12 @@ public interface PrismContainerValueDelegator<C extends Containerable> extends P
 
     default <T> @Nullable T getRealValue() {
         return delegate().getRealValue();
+    }
+
+    @Override
+    default void walk(BiPredicate<? super ItemPath, Boolean> descendPredicate, Predicate<? super ItemPath> consumePredicate,
+            Consumer<? super Item<?, ?>> itemConsumer) throws SchemaException {
+        delegate().walk(descendPredicate, consumePredicate, itemConsumer);
     }
 
 }

--- a/infra/prism-impl/src/test/java/com/evolveum/midpoint/prism/PrismInternalTestUtil.java
+++ b/infra/prism-impl/src/test/java/com/evolveum/midpoint/prism/PrismInternalTestUtil.java
@@ -107,6 +107,7 @@ public class PrismInternalTestUtil implements PrismContextFactory {
     public static final String REF_WITHOUT_FILTER_BASENAME = "ref-without-filter";
 
     public static final String USER_ALICE_METADATA_BASENAME = "user-alice-metadata";
+    public static final File USER_ALICE_METADATA_FILE = new File(COMMON_DIR_XML, USER_ALICE_METADATA_BASENAME + ".xml");
 
     // Namespaces
     public static final String DEFAULT_NAMESPACE_PREFIX = "http://midpoint.evolveum.com/xml/ns";

--- a/infra/prism-impl/src/test/java/com/evolveum/midpoint/prism/TestPrismContainerValueImpl.java
+++ b/infra/prism-impl/src/test/java/com/evolveum/midpoint/prism/TestPrismContainerValueImpl.java
@@ -1,0 +1,114 @@
+package com.evolveum.midpoint.prism;
+
+import static com.evolveum.midpoint.prism.PrismInternalTestUtil.USER_ALICE_METADATA_FILE;
+import static com.evolveum.midpoint.prism.PrismInternalTestUtil.constructInitializedPrismContext;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import com.evolveum.midpoint.prism.impl.PrismContextImpl;
+import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.prism.path.ItemPathCollectionsUtil;
+import com.evolveum.midpoint.util.DOMUtil;
+import com.evolveum.midpoint.util.exception.SchemaException;
+
+public class TestPrismContainerValueImpl extends AbstractPrismTest {
+
+    private PrismObject<Objectable> userWithMetadata;
+    private PrismContextImpl prismContext;
+
+    @BeforeClass
+    void createPrismContext() throws SchemaException, IOException, SAXException {
+        this.prismContext = constructInitializedPrismContext();
+    }
+
+    @BeforeMethod
+    void initUser() throws SchemaException {
+        final Document userWithMetadataXml = DOMUtil.parseFile(USER_ALICE_METADATA_FILE);
+        final Element userWithMetadataXmlElement = DOMUtil.getFirstChildElement(userWithMetadataXml);
+        this.userWithMetadata = prismContext.parserFor(userWithMetadataXmlElement).parse();
+    }
+
+    @Test
+    void userContainsMetadata_metadataAreRemovedFromDeeperStructureUsingPath_metadataShouldNotBePresentAnymore()
+            throws SchemaException {
+        this.userWithMetadata.getValue().removeMetadataFromPaths(ItemPathCollectionsUtil.pathListFromStrings(
+                List.of("assignment/accountConstruction"), this.prismContext));
+
+        final PrismContainerValue<?> assignment = (PrismContainerValue<?>) this.userWithMetadata.getValue().findItem(
+                ItemPath.fromString("assignment")).getValue();
+        final PrismValue accountConstruction = assignment.findItem(ItemPath.fromString("accountConstruction"))
+                .getValue();
+        assertFalse(accountConstruction.hasValueMetadata());
+    }
+
+    @Test
+    void userContainsMetadata_metadataAreRemovedFromWholeBranchUsingPath_metadataShouldNotBePresentAnymore()
+            throws SchemaException {
+        this.userWithMetadata.getValue().removeMetadataFromPaths(ItemPathCollectionsUtil.pathListFromStrings(
+                List.of("assignment", "assignment/accountConstruction"), this.prismContext));
+
+        final PrismContainerValue<?> assignment = (PrismContainerValue<?>) this.userWithMetadata.getValue().findItem(
+                ItemPath.fromString("assignment")).getValue();
+        assertFalse(assignment.hasValueMetadata());
+        final PrismValue accountConstruction = assignment.findItem(ItemPath.fromString("accountConstruction"))
+                .getValue();
+        assertFalse(accountConstruction.hasValueMetadata());
+    }
+
+    @Test
+    void userContainsMetadata_metadataAreRemovedFromSequenceUsingPath_metadataShouldNotBePresentAnymore()
+            throws SchemaException {
+        this.userWithMetadata.getValue().removeMetadataFromPaths(ItemPathCollectionsUtil.pathListFromStrings(
+                List.of("additionalNames"), this.prismContext));
+
+        final Item<PrismValue, ItemDefinition<?>> additionalNamesItem = this.userWithMetadata.getValue().findItem(
+                ItemPath.fromString("additionalNames"));
+        additionalNamesItem.getValues().forEach(additionalName -> assertFalse(additionalName.hasValueMetadata(),
+                "Value metadata of \"additionalName\" property should be removed from the user"));
+    }
+
+    @Test
+    void userContainsMetadata_metadataAreRemovedFromRootUsingPath_metadataShouldNotBePresentAnymore()
+            throws SchemaException {
+        this.userWithMetadata.getValue().removeMetadataFromPaths(ItemPathCollectionsUtil.pathListFromStrings(
+                List.of("/"), this.prismContext));
+
+        assertFalse(this.userWithMetadata.getValue().hasValueMetadata(),
+                "Value metadata of \"additionalName\" property should be removed from the user");
+    }
+
+    @Test
+    void pathsToRemoveAreRelatives_removeDataUsingPath_theUpperObjectShouldBeRemovedWithWholeSubtree()
+            throws SchemaException {
+        this.userWithMetadata.getValue().removePaths(ItemPathCollectionsUtil.pathListFromStrings(
+                List.of("assignment", "assignment/description"), this.prismContext));
+
+        assertNull(userWithMetadata.getValue().findItem(ItemPath.fromString("assignment")),
+                "Assignments should be removed from the user.");
+    }
+
+    @Test
+    void lastPartOfPathToRemoveIsAlsoInParent_removeDataUsingPath_theParentShouldNotBeTouched()
+            throws SchemaException {
+        this.userWithMetadata.getValue().removePaths(ItemPathCollectionsUtil.pathListFromStrings(
+                List.of("assignment/description"), this.prismContext));
+
+
+        assertNotNull(userWithMetadata.getValue().findItem(ItemPath.fromString("description")),
+                "Description should not be removed from the user.");
+        final Object assignmentDescription = userWithMetadata.getValue().findItem(ItemPath.fromString("assignment"))
+                .getValue().find(ItemPath.fromString("description"));
+        assertNull(assignmentDescription, "Description should be removed from the user's assignment.");
+    }
+}

--- a/infra/prism-impl/src/test/resources/common/xml/user-alice-metadata.xml
+++ b/infra/prism-impl/src/test/resources/common/xml/user-alice-metadata.xml
@@ -37,6 +37,24 @@
             <loa>low</loa>
         </_metadata>
     </additionalNames>
+    <description>Alice from the Wonderland</description>
+    <assignment id="1112">
+        <description>Assignment</description>
+        <accountConstruction>
+            <howto>Just do it</howto>
+            <when>2025-01-20T09:31:00.000Z</when>
+            <value>ABC</value>
+            <value>
+                <fullName>Nobody</fullName>
+            </value>
+            <_metadata>
+                <loa>low</loa>
+            </_metadata>
+        </accountConstruction>
+        <_metadata>
+            <loa>low</loa>
+        </_metadata>
+    </assignment>
     <extension>
         <ext:singleStringType>
             <_value>foobar</_value>


### PR DESCRIPTION
**What**

Implement new `PrismContainerValue` method, which allows to delete metadata from specified paths.

**Why**

This function is implemented mainly for the use by REST APIs, which could exclude metadata based on user's request. Till now user could exclude "normal" data, but not metadata.

**Note**

This change also bring new `Walkable` interface, which provide method to walk through container items hierarchy. Implementation of this method is used by the new method for metadata removal as well as for the existing `removePaths` method.

Currently this new interface is extended only by the `PrismContainerValue`. I have considered if it should be extended also by the `PrismContainer` itself, but it would require to write implementation in more places which I am not so far familiar enough. I may add it later if I will be advised to do so.

**Fixes**: MID-10216