### PR TITLE
Apply filter definition on filter value

### DIFF
--- a/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/PrismPropertyValueImpl.java
+++ b/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/PrismPropertyValueImpl.java
@@ -215,6 +215,7 @@ public class PrismPropertyValueImpl<T> extends PrismValueImpl
                         //noinspection unchecked
                         value = (T) XmlTypeConverter.toJavaValue(stringValue, type);
                     } else {
+                        // FIXME This is thrown also in cases when conversion is possible e.g. from int to double
                         throw new SchemaException(
                                 "Incorrect value type. Expected %s (%s) for property '%s', current is: %s".formatted(
                                         definition.getTypeName(), type, definition.getItemName(), value.getClass()));

--- a/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/query/ValueFilterImpl.java
+++ b/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/query/ValueFilterImpl.java
@@ -67,6 +67,8 @@ public abstract class ValueFilterImpl<V extends PrismValue, D extends ItemDefini
         if (values != null) {
             for (V value : values) {
                 value.setParent(this);
+                // Apply the definition in order to convert compatible types (e.g. String to PolyString).
+                applyDefinition(value);
             }
         }
         checkConsistence(false);
@@ -105,6 +107,12 @@ public abstract class ValueFilterImpl<V extends PrismValue, D extends ItemDefini
     @Override
     public void setDefinition(@Nullable D definition) {
         this.definition = definition;
+        if (this.values != null) {
+            // Apply the definition in order to convert compatible types (e.g. String to PolyString).
+            for (V value : this.values) {
+                applyDefinition(value);
+            }
+        }
         checkConsistence(false);
     }
 
@@ -182,6 +190,8 @@ public abstract class ValueFilterImpl<V extends PrismValue, D extends ItemDefini
         this.values = new ArrayList<>();
         if (value != null) {
             value.setParent(this);
+            // Apply the definition in order to convert compatible types (e.g. String to PolyString).
+            applyDefinition(value);
             values.add(value);
         }
     }
@@ -192,6 +202,8 @@ public abstract class ValueFilterImpl<V extends PrismValue, D extends ItemDefini
         this.values = new ArrayList<>();
         for (V value : values) {
             value.setParent(this);
+            // Apply the definition in order to convert compatible types (e.g. String to PolyString).
+            applyDefinition(value);
             this.values.add(value);
         }
     }
@@ -471,6 +483,17 @@ public abstract class ValueFilterImpl<V extends PrismValue, D extends ItemDefini
         // UserType/archetypeRef a ArchetypeType/name
         if (getRightHandSidePath() != null) {
             base.append(getRightHandSidePath()).emitTo(pathConsumer, expandReferences);
+        }
+    }
+
+    private void applyDefinition(V value) {
+        if (this.definition != null) {
+            try {
+                value.applyDefinition(this.definition);
+            } catch (SchemaException e) {
+                // We don't want to wrap it into some runtime exception, because of scripts which may use this filter
+                // in various unknown ways
+            }
         }
     }
 }


### PR DESCRIPTION
**What**

Apply filter definition (if any) to all filter values.

**Why**

It may happen (e.g. when defined by UI or script), that in time of filter creation, the value passed to filter is not of the same type as specified by the definition itself. For some types it is fine (e.g. String value, PolyString in definition), because they can be converted.

In order to "force" this conversion, the definition is now applied to the value on following circumstances:

- Filter is created with both value(s) and definition
- Definition is set to the filter after its creation (via setter)
- Value(s) is added to the filter after its creation (via setter)

The reason, why we want to convert the types using the definition is, that value of this filter may be part of matching with value from repository. Depending on the matcher and normalizer, it may happen that during comparison of those two values, there will be thrown `ClassCastException`, because the types are different and can't be directly cast-ed.

**Note**

The application of definition to value may fail (e.g. when types are not "convertible"). We decided to ignore this event (`SchemaException`) and silently "swallow" it. The reason for this unfortunate thing is that (at this moment) we don't want to change API contract and break backward compatibility, because these filters can be used directly via user's scripts.

**Fixes**: MID-10048

(cherry picked from commit 487a0bac7b29df57718e29358a4b61266c1930eb)