### PR TITLE
MID-11015 Avoid byte array allocation when writing ZIP entries

### DIFF
--- a/infra/util/src/main/java/com/evolveum/midpoint/util/MiscUtil.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/MiscUtil.java
@@ -995,7 +995,9 @@ public class MiscUtil {
         try (ZipOutputStream zipOut = new ZipOutputStream(new FileOutputStream(file))) {
             ZipEntry zipEntry = new ZipEntry(entryName);
             zipOut.putNextEntry(zipEntry);
-            zipOut.write(content.getBytes(charset));
+            try (Writer writer = new OutputStreamWriter(zipOut, charset)) {
+                writer.write(content);
+            }
         }
     }
     // More serious would be to read XML directly from the input stream -- fixme some day

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/MiscUtil.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/MiscUtil.java
@@ -995,9 +995,10 @@ public class MiscUtil {
         try (ZipOutputStream zipOut = new ZipOutputStream(new FileOutputStream(file))) {
             ZipEntry zipEntry = new ZipEntry(entryName);
             zipOut.putNextEntry(zipEntry);
-            try (Writer writer = new OutputStreamWriter(zipOut, charset)) {
-                writer.write(content);
-            }
+            Writer writer = new OutputStreamWriter(zipOut, charset);
+            writer.write(content);
+            writer.flush();
+            zipOut.closeEntry();
         }
     }
     // More serious would be to read XML directly from the input stream -- fixme some day


### PR DESCRIPTION
## Summary

This change avoids creating a full intermediate `byte[]` when writing string content into ZIP entries. `MiscUtil.writeZipFile` now writes the content through an `OutputStreamWriter`, so the string is encoded directly into the `ZipOutputStream` instead of calling `content.getBytes(charset)` first.

This reduces peak memory usage for large ZIP entries and avoids byte-array size limits during trace/diagnostic ZIP writing.

## Testing

- Confirmed ZIP trace writing still produces a valid trace file.