### PR TITLE
Add serialization of allowedValues and suggestedValues to XSD schema

### DIFF
--- a/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/PrismConstants.java
+++ b/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/PrismConstants.java
@@ -114,6 +114,11 @@ public class PrismConstants {
     public static final QName A_PLANNED_REMOVAL = new QName(NS_ANNOTATION, "plannedRemoval");
     public static final QName A_ELABORATE = new QName(NS_ANNOTATION, "elaborate");
     public static final QName A_LABEL = new QName(NS_ANNOTATION, "label");
+    public static final QName A_ALLOWED_VALUES = new QName(NS_ANNOTATION, "allowedValues");
+    public static final QName A_SUGGESTED_VALUES = new QName(NS_ANNOTATION, "suggestedValues");
+    public static final QName A_VALUE = new QName(NS_ANNOTATION, "value");
+    public static final QName A_KEY = new QName(NS_ANNOTATION, "key");
+    public static final QName A_DESCRIPTION = new QName(NS_ANNOTATION, "description");
     public static final QName A_MATCHING_RULE = new QName(NS_ANNOTATION, "matchingRule");
     public static final QName A_EMPHASIZED = new QName(NS_ANNOTATION, "emphasized");
     public static final QName A_DISPLAY_HINT = new QName(NS_ANNOTATION, "displayHint");

--- a/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/schema/SerializablePropertyDefinition.java
+++ b/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/schema/SerializablePropertyDefinition.java
@@ -8,12 +8,16 @@
 package com.evolveum.midpoint.prism.schema;
 
 import com.evolveum.midpoint.prism.PrismReferenceValue;
+import com.evolveum.midpoint.util.DisplayableValue;
 
 import javax.xml.namespace.QName;
+import java.util.Collection;
 
 /** Any property definition that can be serialized. */
-public interface SerializablePropertyDefinition extends SerializableItemDefinition {
+public interface SerializablePropertyDefinition<T> extends SerializableItemDefinition {
 
     QName getMatchingRuleQName();
     PrismReferenceValue getValueEnumerationRef();
+    Collection<? extends DisplayableValue<T>> getAllowedValues();
+    Collection<? extends DisplayableValue<T>> getSuggestedValues();
 }

--- a/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/PrismPropertyDefinitionImpl.java
+++ b/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/PrismPropertyDefinitionImpl.java
@@ -15,7 +15,6 @@ import javax.xml.namespace.QName;
 
 import com.evolveum.midpoint.prism.PrismPropertyDefinition.PrismPropertyLikeDefinitionBuilder;
 import com.evolveum.midpoint.prism.path.ItemName;
-
 import com.evolveum.midpoint.prism.schema.SerializablePropertyDefinition;
 import com.evolveum.midpoint.util.DisplayableValue;
 
@@ -67,7 +66,7 @@ public class PrismPropertyDefinitionImpl<T>
         PrismItemMatchingDefinition.Delegable<T>,
         PrismItemMatchingDefinition.Mutator.Delegable,
         PrismPropertyLikeDefinitionBuilder<T>,
-        SerializablePropertyDefinition {
+        SerializablePropertyDefinition<T> {
 
     // TODO some documentation
     @Serial private static final long serialVersionUID = 7259761997904371009L;
@@ -106,6 +105,16 @@ public class PrismPropertyDefinitionImpl<T>
     public PrismPropertyDefinitionImpl(QName elementName, QName typeName, T defaultValue, QName definedInType) {
         this(elementName, typeName, definedInType);
         setDefaultValue(defaultValue);
+    }
+
+    @Override
+    public Collection<? extends DisplayableValue<T>> getAllowedValues() {
+        return PrismItemValuesDefinition.Delegable.super.getAllowedValues();
+    }
+
+    @Override
+    public Collection<? extends DisplayableValue<T>> getSuggestedValues() {
+        return PrismItemValuesDefinition.Delegable.super.getSuggestedValues();
     }
 
     @Override

--- a/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/SchemaDomSerializer.java
+++ b/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/SchemaDomSerializer.java
@@ -40,6 +40,7 @@ import com.evolveum.midpoint.prism.schema.DefinitionFeatureSerializer.Serializat
 import com.evolveum.midpoint.prism.xml.DynamicNamespacePrefixMapper;
 import com.evolveum.midpoint.prism.xml.XsdTypeMapper;
 import com.evolveum.midpoint.util.DOMUtil;
+import com.evolveum.midpoint.util.DisplayableValue;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
@@ -137,7 +138,7 @@ public class SchemaDomSerializer {
                 if (definition instanceof SerializableContainerDefinition pcd) {
                     // Container definitions are serialized as <complexType> and top-level <element> definitions in XSD.
                     serializeContainerDefinition(pcd, documentRootElement);
-                } else if (definition instanceof SerializablePropertyDefinition ppd) {
+                } else if (definition instanceof SerializablePropertyDefinition<?> ppd) {
                     // Add top-level property definition. It will create <element> XSD definition
                     serializePropertyDefinition(ppd, documentRootElement);
                 } else if (definition instanceof SerializableComplexTypeDefinition
@@ -225,7 +226,7 @@ public class SchemaDomSerializer {
      * @param propertyDef midPoint PropertyDefinition
      * @param parent element under which the definition will be added
      */
-    private void serializePropertyDefinition(SerializablePropertyDefinition propertyDef, Element parent) {
+    private void serializePropertyDefinition(SerializablePropertyDefinition<?> propertyDef, Element parent) {
         Element itemElement = createItemElement(propertyDef, parent);
 
         var appInfo = createAppInfoAnnotationsTarget(itemElement);
@@ -234,6 +235,8 @@ public class SchemaDomSerializer {
 
         addAnnotation(A_MATCHING_RULE, propertyDef.getMatchingRuleQName(), appInfo.appInfoElement);
         addAnnotation(A_VALUE_ENUMERATION_REF, propertyDef.getValueEnumerationRef(), appInfo.appInfoElement);
+        serializeDisplayableValues(A_ALLOWED_VALUES, propertyDef.getAllowedValues(), appInfo.appInfoElement);
+        serializeDisplayableValues(A_SUGGESTED_VALUES, propertyDef.getSuggestedValues(), appInfo.appInfoElement);
 
         addExtraFeatures(propertyDef, appInfo);
 
@@ -343,7 +346,7 @@ public class SchemaDomSerializer {
         definitionsParent.appendChild(sequence);
 
         for (var itemDef : ctd.getDefinitionsToSerialize()) {
-            if (itemDef instanceof SerializablePropertyDefinition ppd) {
+            if (itemDef instanceof SerializablePropertyDefinition<?> ppd) {
                 serializePropertyDefinition(ppd, sequence);
             } else if (itemDef instanceof SerializableContainerDefinition pcd) {
                 serializeContainerDefinition(pcd, sequence);
@@ -421,6 +424,21 @@ public class SchemaDomSerializer {
         aia.removeIfNotNeeded();
 
         return enumeration;
+    }
+
+    private void serializeDisplayableValues(QName wrapperQName, Collection<? extends DisplayableValue<?>> values, Element parent) {
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        Element wrapper = createElement(wrapperQName);
+        parent.appendChild(wrapper);
+        for (DisplayableValue<?> dv : values) {
+            Element valueEl = createElement(A_VALUE);
+            wrapper.appendChild(valueEl);
+            addAnnotation(A_KEY, String.valueOf(dv.getValue()), valueEl);
+            addAnnotation(A_LABEL, dv.getLabel(), valueEl);
+            addAnnotation(A_DESCRIPTION, dv.getDescription(), valueEl);
+        }
     }
 
     private static void addExtraFeatures(SerializableDefinition definition, AppInfoSerializationTarget appInfo) {

--- a/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/SchemaXsomParser.java
+++ b/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/SchemaXsomParser.java
@@ -39,6 +39,7 @@ import org.w3c.dom.Element;
 
 import com.evolveum.midpoint.prism.*;
 import com.evolveum.midpoint.prism.impl.*;
+import com.evolveum.midpoint.prism.impl.DisplayableValueImpl;
 import com.evolveum.midpoint.prism.impl.schema.features.EnumerationValuesInfoXsomParser.EnumValueInfo;
 import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.prism.xml.XmlTypeConverter;
@@ -781,6 +782,10 @@ class SchemaXsomParser {
         DF_INDEX_ONLY.parse(ppdBuilder, annotation);
         DF_MATCHING_RULE.parse(ppdBuilder, annotation);
         DF_VALUE_ENUMERATION_REF.parse(ppdBuilder, annotation);
+        //noinspection unchecked
+        ppdBuilder.setAllowedValues((Collection) parseDisplayableValues(annotation, A_ALLOWED_VALUES));
+        //noinspection unchecked
+        ppdBuilder.setSuggestedValues((Collection) parseDisplayableValues(annotation, A_SUGGESTED_VALUES));
 
         return ppdBuilder;
     }
@@ -842,6 +847,28 @@ class SchemaXsomParser {
             }
         }
         return original;
+    }
+
+    private Collection<? extends DisplayableValue<?>> parseDisplayableValues(
+            @Nullable XSAnnotation annotation, QName wrapperQName) {
+        Element wrapper = getAnnotationElement(annotation, wrapperQName);
+        if (wrapper == null) {
+            return null;
+        }
+        List<DisplayableValue<?>> result = new ArrayList<>();
+        for (Element valueEl : DOMUtil.listChildElements(wrapper)) {
+            List<Element> keyElements = DOMUtil.getChildElements(valueEl, A_KEY);
+            if (keyElements.isEmpty()) {
+                continue;
+            }
+            String key = keyElements.get(0).getTextContent();
+            String label = DOMUtil.getChildElements(valueEl, A_LABEL).stream()
+                    .findFirst().map(Element::getTextContent).orElse(null);
+            String description = DOMUtil.getChildElements(valueEl, A_DESCRIPTION).stream()
+                    .findFirst().map(Element::getTextContent).orElse(null);
+            result.add(new DisplayableValueImpl<>(key, label, description));
+        }
+        return result.isEmpty() ? null : List.copyOf(result);
     }
 
     private void parseItemDefinitionAnnotations(ItemDefinitionLikeBuilder builder, XSAnnotation sourceAnnotation)

--- a/infra/prism-impl/src/main/resources/xml/ns/public/annotation-3.xsd
+++ b/infra/prism-impl/src/main/resources/xml/ns/public/annotation-3.xsd
@@ -1040,4 +1040,34 @@
         </xsd:annotation>
     </xsd:element>
 
+    <xsd:complexType name="DisplayableValueType">
+        <xsd:sequence>
+            <xsd:element name="key" type="xsd:string"/>
+            <xsd:element name="label" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="DisplayableValuesType">
+        <xsd:sequence>
+            <xsd:element name="value" type="tns:DisplayableValueType" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="allowedValues" type="tns:DisplayableValuesType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Property annotation: closed list of allowed values. The user can only select from this list (dropdown).
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:element name="suggestedValues" type="tns:DisplayableValuesType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Property annotation: open list of suggested values. The user can select from this list or enter a custom value (combobox).
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
 </xsd:schema>

--- a/infra/prism-impl/src/test/java/com/evolveum/midpoint/prism/TestPrismSchemaConstruction.java
+++ b/infra/prism-impl/src/test/java/com/evolveum/midpoint/prism/TestPrismSchemaConstruction.java
@@ -15,6 +15,7 @@ import static com.evolveum.midpoint.prism.PrismInternalTestUtil.constructInitial
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import javax.xml.namespace.QName;
 
 import com.evolveum.midpoint.prism.ComplexTypeDefinition.ComplexTypeDefinitionMutator;
@@ -28,6 +29,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
+import com.evolveum.midpoint.prism.impl.DisplayableValueImpl;
 import com.evolveum.midpoint.prism.impl.schema.PrismSchemaImpl;
 import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.prism.schema.PrismSchema;
@@ -125,12 +127,19 @@ public class TestPrismSchemaConstruction extends AbstractPrismTest {
         ComplexTypeDefinitionMutator weaponTypeDef = addNewComplexTypeDefinition(schema, WEAPON_TYPE_LOCAL_NAME).mutator();
         PrismPropertyDefinitionMutator<?> kindPropertyDef = weaponTypeDef.createPropertyDefinition(WEAPON_KIND_QNAME, DOMUtil.XSD_STRING);
         kindPropertyDef.setDisplayName("Weapon kind");
+        //noinspection unchecked
+        ((PrismPropertyDefinition.PrismPropertyDefinitionMutator) kindPropertyDef).setAllowedValues(List.of(
+                new DisplayableValueImpl<>("sword", "Sword", null),
+                new DisplayableValueImpl<>("bow", "Bow", null)));
         weaponTypeDef.createPropertyDefinition(WEAPON_BRAND_LOCAL_NAME, PrismInternalTestUtil.WEAPONS_WEAPON_BRAND_TYPE_QNAME);
         weaponTypeDef.createPropertyDefinition(WEAPON_PASSWORD_LOCAL_NAME, PrismInternalTestUtil.DUMMY_PROTECTED_STRING_TYPE);
         weaponTypeDef.createPropertyDefinition(WEAPON_BLADE_LOCAL_NAME, PrismInternalTestUtil.EXTENSION_BLADE_TYPE_QNAME);
         PrismPropertyDefinitionMutator<?> createTimestampPropertyDef = weaponTypeDef.createPropertyDefinition(WEAPON_CREATE_TIMESTAMP_QNAME, DOMUtil.XSD_DATETIME);
         createTimestampPropertyDef.setDisplayName("Create timestamp");
         createTimestampPropertyDef.setOperational(true);
+        //noinspection unchecked
+        ((PrismPropertyDefinition.PrismPropertyDefinitionMutator) createTimestampPropertyDef).setSuggestedValues(List.of(
+                new DisplayableValueImpl<>("2024-01-01T00:00:00Z", "New Year 2024", null)));
 
         PrismSchemaBuildingUtil.addNewContainerDefinition(schema, WEAPON_LOCAL_NAME, WEAPON_TYPE_LOCAL_NAME);
 
@@ -153,6 +162,9 @@ public class TestPrismSchemaConstruction extends AbstractPrismTest {
         PrismAsserts.assertDefinition(kindPropertyDef, WEAPON_KIND_QNAME, DOMUtil.XSD_STRING, 1, 1);
         assertEquals("Wrong kindPropertyDef displayName", "Weapon kind", kindPropertyDef.getDisplayName());
         assertFalse("kindPropertyDef IS operational", kindPropertyDef.isOperational());
+        Collection<?> allowedValues = kindPropertyDef.getAllowedValues();
+        assertNotNull("kindPropertyDef allowedValues is null", allowedValues);
+        assertEquals("Wrong kindPropertyDef allowedValues size", 2, allowedValues.size());
 
         PrismPropertyDefinition brandPropertyDef = (PrismPropertyDefinition) weaponTypeDefIter.next();
         PrismAsserts.assertDefinition(brandPropertyDef, new QName(NS_MY_SCHEMA, WEAPON_BRAND_LOCAL_NAME),
@@ -170,6 +182,9 @@ public class TestPrismSchemaConstruction extends AbstractPrismTest {
         PrismAsserts.assertDefinition(createTimestampPropertyDef, WEAPON_CREATE_TIMESTAMP_QNAME, DOMUtil.XSD_DATETIME, 1, 1);
         assertEquals("Wrong createTimestampPropertyDef displayName", "Create timestamp", createTimestampPropertyDef.getDisplayName());
         assertTrue("createTimestampPropertyDef not operational", createTimestampPropertyDef.isOperational());
+        Collection<?> suggestedValues = createTimestampPropertyDef.getSuggestedValues();
+        assertNotNull("createTimestampPropertyDef suggestedValues is null", suggestedValues);
+        assertEquals("Wrong createTimestampPropertyDef suggestedValues size", 1, suggestedValues.size());
 
         PrismContainerDefinition<?> weaponContDef = (PrismContainerDefinition<?>) schemaDefIter.next();
         assertEquals("Wrong complex type def in weaponContDef", weaponTypeDef, weaponContDef.getComplexTypeDefinition());


### PR DESCRIPTION
SerializablePropertyDefinition<T> now exposes getAllowedValues() and getSuggestedValues(), enabling SchemaDomSerializer to write them as structured <a:allowedValues>/<a:suggestedValues> annotations in XSD. SchemaXsomParser parses them back into DisplayableValue collections.

This allows connector configuration properties with restricted value sets to survive the schema serialization roundtrip, so the GUI can render dropdowns and comboboxes instead of plain text inputs.