### PR TITLE
Model allowedValues/suggestedValues as DefinitionFeatures

### DIFF
--- a/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionFeatureSerializer.java
+++ b/infra/prism-api/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionFeatureSerializer.java
@@ -7,9 +7,12 @@
 
 package com.evolveum.midpoint.prism.schema;
 
+import java.util.Collection;
 import javax.xml.namespace.QName;
 
 import org.jetbrains.annotations.NotNull;
+
+import com.evolveum.midpoint.util.DisplayableValue;
 
 /**
  * Serializes given feature, currently into XSD DOM.
@@ -28,5 +31,11 @@ public interface DefinitionFeatureSerializer<V> {
         void addAnnotation(QName name, String value);
         void addAnnotation(QName qname, QName value);
         void addRefAnnotation(QName qname, QName value);
+
+        /**
+         * Adds a wrapper element ({@code wrapperName}) holding a structured {@code <value>} child element
+         * for each {@link DisplayableValue} (key/label/description). Used for {@code allowedValues}/{@code suggestedValues}.
+         */
+        void addDisplayableValues(QName wrapperName, Collection<? extends DisplayableValue<?>> values);
     }
 }

--- a/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/SchemaDomSerializer.java
+++ b/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/SchemaDomSerializer.java
@@ -13,6 +13,8 @@ import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
 
 import static com.evolveum.midpoint.prism.PrismConstants.*;
 import static com.evolveum.midpoint.prism.impl.schema.features.DefinitionFeatures.DF_ACCESS;
+import static com.evolveum.midpoint.prism.impl.schema.features.DefinitionFeatures.DF_ALLOWED_VALUES;
+import static com.evolveum.midpoint.prism.impl.schema.features.DefinitionFeatures.DF_SUGGESTED_VALUES;
 import static com.evolveum.midpoint.util.MiscUtil.argNonNull;
 
 import java.util.Collection;
@@ -235,8 +237,8 @@ public class SchemaDomSerializer {
 
         addAnnotation(A_MATCHING_RULE, propertyDef.getMatchingRuleQName(), appInfo.appInfoElement);
         addAnnotation(A_VALUE_ENUMERATION_REF, propertyDef.getValueEnumerationRef(), appInfo.appInfoElement);
-        serializeDisplayableValues(A_ALLOWED_VALUES, propertyDef.getAllowedValues(), appInfo.appInfoElement);
-        serializeDisplayableValues(A_SUGGESTED_VALUES, propertyDef.getSuggestedValues(), appInfo.appInfoElement);
+        DF_ALLOWED_VALUES.serialize(propertyDef, appInfo);
+        DF_SUGGESTED_VALUES.serialize(propertyDef, appInfo);
 
         addExtraFeatures(propertyDef, appInfo);
 
@@ -689,6 +691,11 @@ public class SchemaDomSerializer {
                         A_REF.getLocalPart(),
                         value);
             }
+        }
+
+        @Override
+        public void addDisplayableValues(QName wrapperName, Collection<? extends DisplayableValue<?>> values) {
+            schemaSerializer.serializeDisplayableValues(wrapperName, values, appInfoElement);
         }
 
         private Element addNewElement(QName qname) {

--- a/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/SchemaXsomParser.java
+++ b/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/SchemaXsomParser.java
@@ -782,10 +782,10 @@ class SchemaXsomParser {
         DF_INDEX_ONLY.parse(ppdBuilder, annotation);
         DF_MATCHING_RULE.parse(ppdBuilder, annotation);
         DF_VALUE_ENUMERATION_REF.parse(ppdBuilder, annotation);
-        //noinspection unchecked
-        ppdBuilder.setAllowedValues((Collection) parseDisplayableValues(annotation, A_ALLOWED_VALUES));
-        //noinspection unchecked
-        ppdBuilder.setSuggestedValues((Collection) parseDisplayableValues(annotation, A_SUGGESTED_VALUES));
+        // These are non-destructive by construction: the feature is applied only when its annotation
+        // is actually present, so enum-derived allowed values set above (parseEnumAllowedValues) are kept.
+        DF_ALLOWED_VALUES.parse(ppdBuilder, annotation);
+        DF_SUGGESTED_VALUES.parse(ppdBuilder, annotation);
 
         return ppdBuilder;
     }
@@ -847,28 +847,6 @@ class SchemaXsomParser {
             }
         }
         return original;
-    }
-
-    private Collection<? extends DisplayableValue<?>> parseDisplayableValues(
-            @Nullable XSAnnotation annotation, QName wrapperQName) {
-        Element wrapper = getAnnotationElement(annotation, wrapperQName);
-        if (wrapper == null) {
-            return null;
-        }
-        List<DisplayableValue<?>> result = new ArrayList<>();
-        for (Element valueEl : DOMUtil.listChildElements(wrapper)) {
-            List<Element> keyElements = DOMUtil.getChildElements(valueEl, A_KEY);
-            if (keyElements.isEmpty()) {
-                continue;
-            }
-            String key = keyElements.get(0).getTextContent();
-            String label = DOMUtil.getChildElements(valueEl, A_LABEL).stream()
-                    .findFirst().map(Element::getTextContent).orElse(null);
-            String description = DOMUtil.getChildElements(valueEl, A_DESCRIPTION).stream()
-                    .findFirst().map(Element::getTextContent).orElse(null);
-            result.add(new DisplayableValueImpl<>(key, label, description));
-        }
-        return result.isEmpty() ? null : List.copyOf(result);
     }
 
     private void parseItemDefinitionAnnotations(ItemDefinitionLikeBuilder builder, XSAnnotation sourceAnnotation)

--- a/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/features/DefinitionFeatures.java
+++ b/infra/prism-impl/src/main/java/com/evolveum/midpoint/prism/impl/schema/features/DefinitionFeatures.java
@@ -12,11 +12,14 @@ import static com.evolveum.midpoint.prism.impl.schema.SchemaProcessorUtil.*;
 import static com.evolveum.midpoint.prism.impl.schema.SchemaProcessorUtil.getAnnotationElement;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import javax.xml.namespace.QName;
 
 import com.evolveum.midpoint.prism.*;
+import com.evolveum.midpoint.prism.impl.DisplayableValueImpl;
+import com.evolveum.midpoint.util.DisplayableValue;
 
 import com.evolveum.midpoint.prism.ComplexTypeDefinition.ComplexTypeDefinitionLikeBuilder;
 
@@ -264,6 +267,28 @@ public class DefinitionFeatures {
                         return new PrismReferenceValueImpl(oid, targetType);
                     });
 
+    @SuppressWarnings("rawtypes") // same as DF_VALUE_ENUMERATION_REF above
+    public static final DefinitionFeature<Collection, PrismItemValuesDefinition.Mutator, XSAnnotation, ?> DF_ALLOWED_VALUES =
+            DefinitionFeature.of(
+                    Collection.class,
+                    PrismItemValuesDefinition.Mutator.class,
+                    PrismItemValuesDefinition.Mutator::setAllowedValues,
+                    XsomParsers.displayableValues(A_ALLOWED_VALUES),
+                    SerializablePropertyDefinition.class,
+                    SerializablePropertyDefinition::getAllowedValues,
+                    XsdSerializers.displayableValues(A_ALLOWED_VALUES));
+
+    @SuppressWarnings("rawtypes") // same as DF_VALUE_ENUMERATION_REF above
+    public static final DefinitionFeature<Collection, PrismItemValuesDefinition.Mutator, XSAnnotation, ?> DF_SUGGESTED_VALUES =
+            DefinitionFeature.of(
+                    Collection.class,
+                    PrismItemValuesDefinition.Mutator.class,
+                    PrismItemValuesDefinition.Mutator::setSuggestedValues,
+                    XsomParsers.displayableValues(A_SUGGESTED_VALUES),
+                    SerializablePropertyDefinition.class,
+                    SerializablePropertyDefinition::getSuggestedValues,
+                    XsdSerializers.displayableValues(A_SUGGESTED_VALUES));
+
     public static class XsomParsers {
 
         public static final IsAnyXsomParser DF_IS_ANY_XSD_PARSER = IsAnyXsomParser.instance();
@@ -414,6 +439,39 @@ public class DefinitionFeatures {
                 @Override
                 public @Nullable T getValue(@Nullable XSAnnotation annotation) throws SchemaException {
                     return getAnnotationConverted(annotation, name, valueClass);
+                }
+            };
+        }
+
+        /**
+         * Parses a wrapper annotation element (e.g. {@code <a:allowedValues>}) holding structured
+         * {@code <a:value>} children into a collection of {@link DisplayableValue}s. Returns {@code null}
+         * when the wrapper is absent, so that values from other sources (e.g. {@code xsd:enumeration})
+         * are not overwritten. See {@link #DF_ALLOWED_VALUES} / {@link #DF_SUGGESTED_VALUES}.
+         */
+        @SuppressWarnings("rawtypes")
+        public static DefinitionFeatureParser<Collection, XSAnnotation> displayableValues(@NotNull QName wrapperQName) {
+            return new DefinitionFeatureParser<>() {
+                @Override
+                public @Nullable Collection getValue(@Nullable XSAnnotation annotation) {
+                    Element wrapper = getAnnotationElement(annotation, wrapperQName);
+                    if (wrapper == null) {
+                        return null;
+                    }
+                    List<DisplayableValue<?>> result = new ArrayList<>();
+                    for (Element valueElement : DOMUtil.listChildElements(wrapper)) {
+                        List<Element> keyElements = DOMUtil.getChildElements(valueElement, A_KEY);
+                        if (keyElements.isEmpty()) {
+                            continue;
+                        }
+                        String key = keyElements.get(0).getTextContent();
+                        String label = DOMUtil.getChildElements(valueElement, A_LABEL).stream()
+                                .findFirst().map(Element::getTextContent).orElse(null);
+                        String description = DOMUtil.getChildElements(valueElement, A_DESCRIPTION).stream()
+                                .findFirst().map(Element::getTextContent).orElse(null);
+                        result.add(new DisplayableValueImpl<>(key, label, description));
+                    }
+                    return result.isEmpty() ? null : List.copyOf(result);
                 }
             };
         }
@@ -580,6 +638,11 @@ public class DefinitionFeatures {
         public static <E extends Enum<E>> @NotNull DefinitionFeatureSerializer<E> enumBased(
                 Class<E> valueClass, @NotNull QName annotationName, @NotNull Function<E, String> valueExtractor) {
             return (value, target) -> target.addAnnotation(annotationName, valueExtractor.apply(value));
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        public static @NotNull DefinitionFeatureSerializer<Collection> displayableValues(@NotNull QName wrapperName) {
+            return (value, target) -> target.addDisplayableValues(wrapperName, value);
         }
     }
 }

--- a/infra/prism-impl/src/test/java/com/evolveum/midpoint/prism/TestPrismSchemaConstruction.java
+++ b/infra/prism-impl/src/test/java/com/evolveum/midpoint/prism/TestPrismSchemaConstruction.java
@@ -35,6 +35,7 @@ import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.prism.schema.PrismSchema;
 import com.evolveum.midpoint.prism.util.PrismAsserts;
 import com.evolveum.midpoint.util.DOMUtil;
+import com.evolveum.midpoint.util.DisplayableValue;
 import com.evolveum.midpoint.util.PrettyPrinter;
 import com.evolveum.midpoint.util.exception.SchemaException;
 
@@ -119,6 +120,49 @@ public class TestPrismSchemaConstruction extends AbstractPrismTest {
         System.out.println("Re-parsed schema");
         System.out.println(reparsedSchema.debugDump());
         assertSchema(reparsedSchema);
+    }
+
+    /**
+     * Regression test: allowed values derived from {@code xsd:enumeration} facets must not be wiped out
+     * when parsing a property that has no {@code <a:allowedValues>} annotation. Such a schema is
+     * hand-written (the long-standing enum mechanism); the enum {@code simpleType} is the only source
+     * of allowed values, so they must survive the parse.
+     */
+    @Test
+    public void testEnumerationAllowedValuesSurviveParsing() throws Exception {
+        PrismContext ctx = constructInitializedPrismContext();
+
+        String xsd = ""
+                + "<xsd:schema elementFormDefault='qualified'"
+                + "            targetNamespace='" + NS_MY_SCHEMA + "'"
+                + "            xmlns:tns='" + NS_MY_SCHEMA + "'"
+                + "            xmlns:a='" + PrismConstants.NS_ANNOTATION + "'"
+                + "            xmlns:xsd='http://www.w3.org/2001/XMLSchema'>"
+                + "    <xsd:simpleType name='MarkType'>"
+                + "        <xsd:restriction base='xsd:string'>"
+                + "            <xsd:enumeration value='pegLeg'/>"
+                + "            <xsd:enumeration value='noEye'/>"
+                + "            <xsd:enumeration value='hook'/>"
+                + "        </xsd:restriction>"
+                + "    </xsd:simpleType>"
+                + "    <xsd:complexType name='PirateType'>"
+                + "        <xsd:sequence>"
+                + "            <xsd:element name='mark' type='tns:MarkType' minOccurs='0'/>"
+                + "        </xsd:sequence>"
+                + "    </xsd:complexType>"
+                + "</xsd:schema>";
+
+        Element xsdElement = DOMUtil.getFirstChildElement(DOMUtil.parseDocument(xsd));
+        PrismSchema schema = SchemaParsingUtil.createAndParse(xsdElement, true, "enum regression schema");
+
+        ComplexTypeDefinition pirateTypeDef = schema.findComplexTypeDefinitionByType(new QName(NS_MY_SCHEMA, "PirateType"));
+        assertNotNull("No PirateType definition", pirateTypeDef);
+        PrismPropertyDefinition<?> markDef = pirateTypeDef.findPropertyDefinition(new ItemName(NS_MY_SCHEMA, "mark"));
+        assertNotNull("No mark property definition", markDef);
+
+        Collection<? extends DisplayableValue<?>> allowedValues = markDef.getAllowedValues();
+        assertNotNull("Enum-derived allowedValues were wiped out", allowedValues);
+        assertEquals("Wrong number of enum allowed values", 3, allowedValues.size());
     }
 
     private PrismSchema constructSchema() {


### PR DESCRIPTION
The previous commit parsed the <a:allowedValues>/<a:suggestedValues> appinfo annotations with inline setAllowedValues(parseDisplayableValues(...)) calls in SchemaXsomParser. These set the values unconditionally, and the parser returns null when the annotation is absent. For properties whose allowed values come from xsd:enumeration facets, this overwrote the enumeration-derived values with null, so getAllowedValues() returned null.

Route both parsing and serialization through the DefinitionFeature framework (DF_ALLOWED_VALUES / DF_SUGGESTED_VALUES), like indexOnly, matchingRule and valueEnumerationRef. DefinitionFeature.parse() applies a feature only when its annotation is present and the value is non-null, so enum-derived values are no longer clobbered - the regression cannot occur by construction. Parse and serialize now live together in DefinitionFeatures.

Adds SerializationTarget.addDisplayableValues() so the structured allowedValues/suggestedValues can be serialized through the framework.